### PR TITLE
Förbättrad API för Yaml-datatyper

### DIFF
--- a/YamlValidator/Schema.h
+++ b/YamlValidator/Schema.h
@@ -5,30 +5,10 @@
 #include <vector>
 #include <variant>
 
+#include "Types.h"
 #include "YamlParser.h"
 
-// The type values for defining a Schema
-enum YamlType {
-	String,
-	Number,
-	Boolean,
-	Null,
-};
-
-class Object;
-class Array;
-
-using kvPair = std::pair<std::string, std::variant<YamlType, Array, Object>>;
-
-class Array {
-	Array(YamlType input) {}
-	Array(std::initializer_list<kvPair> input) {}
-};
-
-class Object {
-	Object(kvPair input[]) {}
-	Object(std::initializer_list<kvPair> input) {}
-};
+using kvPair = std::pair<std::string, YamlValue>;
 
 // Ok and Error defined in YamlParser.h
 // TODO: move Ok and Error to global space?

--- a/YamlValidator/Types.h
+++ b/YamlValidator/Types.h
@@ -5,50 +5,48 @@
 #include <unordered_map>
 #include <vector>
 #include <optional>
+#include <memory>
 
-class String {
-	const std::string& value;
+struct String {
+	std::string value;
 	String(const std::string& value) : value(value) {}
 	String(const char value[]) : value(value) {}
 
 	bool operator<(const String& other) const { return value < other.value; };
 };
 
-class Number {
-	const std::string& value;
+struct Number {
+	std::string value;
 	Number(const std::string& value) : value(value) {}
 	Number(const char value[]) : value(value) {}
 };
 
-class Boolean {
+struct Boolean {
 	bool value;
 	Boolean(const bool value) : value(value) {}
 };
 
-class Null {};
+struct Null {};
 
 class Object;
 class Array;
 
-using YamlValue = std::variant<String, Number, Boolean, Null, Object, Array>;
+using YamlValue = std::variant<String, Number, Boolean, Null, std::shared_ptr<Object>, std::shared_ptr<Array>>;
+using Yaml = std::variant<std::shared_ptr<Object>, std::shared_ptr<Array>>;
 
 class Object {
 private:
-	std::unordered_map<String, YamlValue> map;
+	std::unordered_map<std::string, YamlValue> map;
 
 public:
 	Object() {}
-
-	void Set(const std::string& key, const YamlValue& value) {
-		map.insert_or_assign(key, value);
+	
+	void Set(const std::string& key, YamlValue& value) {
+		map.emplace(key, std::move(value));
 	}
 
-	void Set(const std::pair<String, YamlValue> kv) {
-		map.insert_or_assign(kv.first, kv.second);
-	}
-
-	void Set(const std::pair<std::string, YamlValue> kv) {
-		map.insert_or_assign(String(kv.first), kv.second);
+	void Set(std::pair<std::string, YamlValue> kv) {
+		map.emplace(kv.first, std::move(kv.second));
 	}
 
 	std::optional<YamlValue> Get(const std::string& key) const {
@@ -86,6 +84,8 @@ private:
 	std::vector<YamlValue> values;
 
 public:
+	Array() {}
+
 	void PushBack(const YamlValue& value) {
 		values.push_back(value);
 	}
@@ -96,9 +96,13 @@ public:
 
 	std::optional<YamlValue> Get(const size_t index) const {
 		if (index < values.size()) {
-			return values[index];
+			return std::optional<YamlValue>(values[index]);
 		}
 		return std::nullopt;
+	}
+
+	YamlValue operator[](const size_t index) const {
+		return values[index];
 	}
 
 	size_t Size() const {
@@ -112,4 +116,4 @@ public:
 	void Clear() {
 		values.clear();
 	}
-}
+};

--- a/YamlValidator/YamlParser.cpp
+++ b/YamlValidator/YamlParser.cpp
@@ -8,43 +8,44 @@ void YamlParser::Expect(char c) {}
 
 void YamlParser::ExpectEither(std::initializer_list<char> list) {}
 
-_String YamlParser::ParseString() {
-	return _String("test");
+String YamlParser::ParseString() {
+	return String("test");
 }
 
-_Number YamlParser::ParseNumber() {
-	return _Number("123");
+Number YamlParser::ParseNumber() {
+	return Number("123");
 }
 
-_Boolean YamlParser::ParseBoolean() {
-	return _Boolean(true);
+Boolean YamlParser::ParseBoolean() {
+	return Boolean(true);
 }
 
-_Null YamlParser::ParseNull() {
-	return _Null();
+Null YamlParser::ParseNull() {
+	return Null();
 }
 
-_Object YamlParser::ParseYamlObject() {
-	std::map<_String, YamlValue> obj;
-	return _Object(obj);
+Object YamlParser::ParseYamlObject() {
+	Object obj;
+	obj.Set({ "key", String("value") });
+	return obj;
 }
 
-_Object YamlParser::ParseJsonObject() {
-	std::map<_String, YamlValue> obj;
-	obj.insert(std::pair("key", _String("value")));
-	return _Object(obj);
+Object YamlParser::ParseJsonObject() {
+	Object obj;
+	obj.Set({ "key", String("value") });
+	return obj;
 }
 
-_Array YamlParser::ParseYamlArray() {
-	std::vector<YamlValue> values;
-	values.push_back(_String("test"));
-	return _Array(values);
+Array YamlParser::ParseYamlArray() {
+	Array arr;
+	arr.PushBack(String("Array value"));
+	return arr;
 }
 
-_Array YamlParser::ParseJsonArray() {
-	std::vector<YamlValue> values;
-	values.push_back(_String("test"));
-	return _Array(values);
+Array YamlParser::ParseJsonArray() {
+	Array arr;
+	arr.PushBack(String("Array value"));
+	return arr;
 }
 
 ParserResult YamlParser::Parse() {

--- a/YamlValidator/YamlParser.h
+++ b/YamlValidator/YamlParser.h
@@ -5,55 +5,16 @@
 #include <fstream>
 #include <map>
 
-// Data types for internal use
-
-struct _String {
-public:
-	const std::string& value;
-	_String(const std::string& value) : value(value) {}
-	_String(const char value[]) : value(value) {}
-};
-
-struct _Number {
-public:
-	std::string value;
-	_Number(std::string& value) : value(value) {}
-	_Number(const char value[]) : value(value) {}
-};
-
-struct _Boolean {
-public:
-	bool value;
-	_Boolean(bool value) : value(value) {}
-};
-
-struct _Null {};
-
-class _Object;
-class _Array;
-
-using YamlValue = std::variant<_String, _Number, _Boolean, _Null, _Object, _Array>;
-using Yaml = std::variant<_Object, _Array>;
-
-class _Object {
-public:
-	const std::map<_String, YamlValue>& values;
-	_Object(const std::map<_String, YamlValue>& values) : values(values) {}
-};
-
-class _Array {
-public:
-	const std::vector<YamlValue>& values;
-	_Array(const std::vector<YamlValue>& values) : values(values) {}
-};
-
-// Parser result
+#include "Types.h"
 
 struct Ok {};
+
 struct Error {
 	std::string& message;
 };
+
 using ParserResult = std::variant<Ok, Error>;
+
 
 class YamlParser {
 private:
@@ -70,15 +31,15 @@ private:
 	void Expect(char c);
 	void ExpectEither(std::initializer_list<char> list);
 
-	_String ParseString();
-	_Number ParseNumber();
-	_Boolean ParseBoolean();
-	_Null ParseNull();
+	String ParseString();
+	Number ParseNumber();
+	Boolean ParseBoolean();
+	Null ParseNull();
 
-	_Object ParseYamlObject();
-	_Object ParseJsonObject();
-	_Array ParseYamlArray();
-	_Array ParseJsonArray();
+	Object ParseYamlObject();
+	Object ParseJsonObject();
+	Array ParseYamlArray();
+	Array ParseJsonArray();
 	
 public:
 	YamlParser(std::ifstream& stream) : stream(stream) {
@@ -89,10 +50,6 @@ public:
 	ParserResult Parse();
 };
 
-ParserResult ParseYaml(std::string& filePath) {
-	std::ifstream stream(filePath);
-	YamlParser parser(stream);
-	return parser.Parse();
-}
+ParserResult ParseYaml(std::string& filePath);
 
 

--- a/YamlValidator/YamlValidator.cpp
+++ b/YamlValidator/YamlValidator.cpp
@@ -1,11 +1,11 @@
-#include "Schema.h"
+
 
 int main() {
-	Schema blogSchema({
+	/*Schema blogSchema({
 		{ "title", String },
 		{ "author", String },
 		{ "body", String }
-	});
+	});*/
 
 	/*
 	Schema anotherBlogSchema({


### PR DESCRIPTION
String och Number höll tidigare referenser till sin data, vilket inte är att föredra i detta fallet. De ska istället äga sin egen data.

Typerna YamlValue och Yaml använder nu sig av `std::shared_ptr`, vilket (enligt Bing Copilot) var tvunget eftersom `std::variant` inte känner till storleken på Object och Array när YamlValue och Yaml skapas.

Object-klassen använder nu `std::string` som key i `std::unordered_map`. Detta för att slippa problem med hashing, men även för att förenkla APIn.

`map.insert_or_assign()` har ersatts av `map.emplace()` då `map.insert_or_assign()` skapar en temporär kopia i minnet, men `map.emplace()` gör inte det, alltså förbättrar prestanda och minskar minnesförbrukning.