### PR TITLE
ParserTypes namespace för Types.h

### DIFF
--- a/YamlValidator/Schema.h
+++ b/YamlValidator/Schema.h
@@ -8,7 +8,7 @@
 #include "Types.h"
 #include "YamlParser.h"
 
-using kvPair = std::pair<std::string, YamlValue>;
+using kvPair = std::pair<std::string, ParserTypes::YamlValue>;
 
 class Schema {
 private:

--- a/YamlValidator/Types.h
+++ b/YamlValidator/Types.h
@@ -7,113 +7,116 @@
 #include <optional>
 #include <memory>
 
-struct String {
-	std::string value;
-	String(const std::string& value) : value(value) {}
-	String(const char value[]) : value(value) {}
+namespace ParserTypes {
 
-	bool operator<(const String& other) const { return value < other.value; };
-};
+	struct String {
+		std::string value;
+		String(const std::string& value) : value(value) {}
+		String(const char value[]) : value(value) {}
 
-struct Number {
-	std::string value;
-	Number(const std::string& value) : value(value) {}
-	Number(const char value[]) : value(value) {}
-};
+		bool operator<(const String& other) const { return value < other.value; };
+	};
 
-struct Boolean {
-	bool value;
-	Boolean(const bool value) : value(value) {}
-};
+	struct Number {
+		std::string value;
+		Number(const std::string& value) : value(value) {}
+		Number(const char value[]) : value(value) {}
+	};
 
-struct Null {};
+	struct Boolean {
+		bool value;
+		Boolean(const bool value) : value(value) {}
+	};
 
-class Object;
-class Array;
+	struct Null {};
 
-using YamlValue = std::variant<String, Number, Boolean, Null, std::shared_ptr<Object>, std::shared_ptr<Array>>;
-using Yaml = std::variant<std::shared_ptr<Object>, std::shared_ptr<Array>>;
+	class Object;
+	class Array;
 
-class Object {
-private:
-	std::unordered_map<std::string, YamlValue> map;
+	using YamlValue = std::variant<String, Number, Boolean, Null, std::shared_ptr<Object>, std::shared_ptr<Array>>;
+	using Yaml = std::variant<std::shared_ptr<Object>, std::shared_ptr<Array>>;
 
-public:
-	Object() {}
-	
-	void Set(const std::string& key, YamlValue& value) {
-		map.emplace(key, std::move(value));
-	}
+	class Object {
+	private:
+		std::unordered_map<std::string, YamlValue> map;
 
-	void Set(std::pair<std::string, YamlValue> kv) {
-		map.emplace(kv.first, std::move(kv.second));
-	}
+	public:
+		Object() {}
 
-	std::optional<YamlValue> Get(const std::string& key) const {
-		auto it = map.find(key);
-		if (it != map.end()) {
-			return it->second;
+		void Set(const std::string& key, YamlValue& value) {
+			map.emplace(key, std::move(value));
 		}
-		return std::nullopt;
-	}
 
-	std::vector<std::string> ExtractKeys() const {
-		std::vector<std::string> keys;
-		keys.reserve(map.size());
-		for (const auto& pair : map) {
-			keys.push_back(pair.first);
+		void Set(std::pair<std::string, YamlValue> kv) {
+			map.emplace(kv.first, std::move(kv.second));
 		}
-		return keys;
-	}
 
-	bool ContainsKey(const std::string& key) const {
-		return map.find(key) != map.end();
-	}
-
-	size_t Size() const {
-		return map.size();
-	}
-
-	void Clear() {
-		map.clear();
-	}
-};
-
-class Array {
-private:
-	std::vector<YamlValue> values;
-
-public:
-	Array() {}
-
-	void PushBack(const YamlValue& value) {
-		values.push_back(value);
-	}
-
-	void PopBack() {
-		values.pop_back();
-	}
-
-	std::optional<YamlValue> Get(const size_t index) const {
-		if (index < values.size()) {
-			return std::optional<YamlValue>(values[index]);
+		std::optional<YamlValue> Get(const std::string& key) const {
+			auto it = map.find(key);
+			if (it != map.end()) {
+				return it->second;
+			}
+			return std::nullopt;
 		}
-		return std::nullopt;
-	}
 
-	YamlValue operator[](const size_t index) const {
-		return values[index];
-	}
+		std::vector<std::string> ExtractKeys() const {
+			std::vector<std::string> keys;
+			keys.reserve(map.size());
+			for (const auto& pair : map) {
+				keys.push_back(pair.first);
+			}
+			return keys;
+		}
 
-	size_t Size() const {
-		return values.size();
-	}
+		bool ContainsKey(const std::string& key) const {
+			return map.find(key) != map.end();
+		}
 
-	bool IsEmpty() const {
-		return values.empty();
-	}
+		size_t Size() const {
+			return map.size();
+		}
 
-	void Clear() {
-		values.clear();
-	}
+		void Clear() {
+			map.clear();
+		}
+	};
+
+	class Array {
+	private:
+		std::vector<YamlValue> values;
+
+	public:
+		Array() {}
+
+		void PushBack(const YamlValue& value) {
+			values.push_back(value);
+		}
+
+		void PopBack() {
+			values.pop_back();
+		}
+
+		std::optional<YamlValue> Get(const size_t index) const {
+			if (index < values.size()) {
+				return std::optional<YamlValue>(values[index]);
+			}
+			return std::nullopt;
+		}
+
+		YamlValue operator[](const size_t index) const {
+			return values[index];
+		}
+
+		size_t Size() const {
+			return values.size();
+		}
+
+		bool IsEmpty() const {
+			return values.empty();
+		}
+
+		void Clear() {
+			values.clear();
+		}
+	};
 };

--- a/YamlValidator/YamlParser.cpp
+++ b/YamlValidator/YamlParser.cpp
@@ -8,42 +8,42 @@ void YamlParser::Expect(char c) {}
 
 void YamlParser::ExpectEither(std::initializer_list<char> list) {}
 
-ParserTypes::String YamlParser::ParseString() {
-	return ParserTypes::String("test");
+String YamlParser::ParseString() {
+	return String("test");
 }
 
-ParserTypes::Number YamlParser::ParseNumber() {
-	return ParserTypes::Number("123");
+Number YamlParser::ParseNumber() {
+	return Number("123");
 }
 
-ParserTypes::Boolean YamlParser::ParseBoolean() {
-	return ParserTypes::Boolean(true);
+Boolean YamlParser::ParseBoolean() {
+	return Boolean(true);
 }
 
-ParserTypes::Null YamlParser::ParseNull() {
-	return ParserTypes::Null();
+Null YamlParser::ParseNull() {
+	return Null();
 }
 
-ParserTypes::Object YamlParser::ParseYamlObject() {
-	return ParserTypes::Object();
+Object YamlParser::ParseYamlObject() {
+	return Object();
 }
 
-ParserTypes::Object YamlParser::ParseJsonObject() {
-	return ParserTypes::Object();
+Object YamlParser::ParseJsonObject() {
+	return Object();
 }
 
-ParserTypes::Array YamlParser::ParseYamlArray() {
-	ParserTypes::Array arr;
+Array YamlParser::ParseYamlArray() {
+	Array arr;
 	return arr;
 }
 
-ParserTypes::Array YamlParser::ParseJsonArray() {
-	ParserTypes::Array arr;
+Array YamlParser::ParseJsonArray() {
+	Array arr;
 	return arr;
 }
 
 ParserResult YamlParser::Parse() {
-	std::shared_ptr<ParserTypes::Array> yaml = std::make_shared<ParserTypes::Array>(ParseYamlArray());
+	std::shared_ptr<Array> yaml = std::make_shared<Array>(ParseYamlArray());
 	return ParserResult(yaml);
 }
 

--- a/YamlValidator/YamlParser.cpp
+++ b/YamlValidator/YamlParser.cpp
@@ -8,42 +8,42 @@ void YamlParser::Expect(char c) {}
 
 void YamlParser::ExpectEither(std::initializer_list<char> list) {}
 
-String YamlParser::ParseString() {
-	return String("test");
+ParserTypes::String YamlParser::ParseString() {
+	return ParserTypes::String("test");
 }
 
-Number YamlParser::ParseNumber() {
-	return Number("123");
+ParserTypes::Number YamlParser::ParseNumber() {
+	return ParserTypes::Number("123");
 }
 
-Boolean YamlParser::ParseBoolean() {
-	return Boolean(true);
+ParserTypes::Boolean YamlParser::ParseBoolean() {
+	return ParserTypes::Boolean(true);
 }
 
-Null YamlParser::ParseNull() {
-	return Null();
+ParserTypes::Null YamlParser::ParseNull() {
+	return ParserTypes::Null();
 }
 
-Object YamlParser::ParseYamlObject() {
-	return Object();
+ParserTypes::Object YamlParser::ParseYamlObject() {
+	return ParserTypes::Object();
 }
 
-Object YamlParser::ParseJsonObject() {
-	return Object();
+ParserTypes::Object YamlParser::ParseJsonObject() {
+	return ParserTypes::Object();
 }
 
-Array YamlParser::ParseYamlArray() {
-	Array arr;
+ParserTypes::Array YamlParser::ParseYamlArray() {
+	ParserTypes::Array arr;
 	return arr;
 }
 
-Array YamlParser::ParseJsonArray() {
-	Array arr;
+ParserTypes::Array YamlParser::ParseJsonArray() {
+	ParserTypes::Array arr;
 	return arr;
 }
 
 ParserResult YamlParser::Parse() {
-	std::shared_ptr<Array> yaml = std::make_shared<Array>(ParseYamlArray());
+	std::shared_ptr<ParserTypes::Array> yaml = std::make_shared<ParserTypes::Array>(ParseYamlArray());
 	return ParserResult(yaml);
 }
 

--- a/YamlValidator/YamlParser.h
+++ b/YamlValidator/YamlParser.h
@@ -15,22 +15,22 @@ enum ParserError {
 
 class ParserResult {
 private:
-	std::variant<Yaml, ParserError> result;
+	std::variant<ParserTypes::Yaml, ParserError> result;
 
 public:
-	ParserResult(Yaml ok) : result(ok) {}
+	ParserResult(ParserTypes::Yaml ok) : result(ok) {}
 	ParserResult(ParserError error) : result(error) {}
 
-	bool IsOk() const { return std::holds_alternative<Yaml>(result); }
+	bool IsOk() const { return std::holds_alternative<ParserTypes::Yaml>(result); }
 
 	bool IsError() const { return std::holds_alternative<ParserError>(result); }
 
-	Yaml GetResult() const { return std::get<Yaml>(result); }
+	ParserTypes::Yaml GetResult() const { return std::get<ParserTypes::Yaml>(result); }
 
 	ParserError GetError() const { return std::get<ParserError>(result); }
 
-	std::optional<Yaml> GetIfOk() const {
-		if (std::holds_alternative<Yaml>(result)) return std::get<Yaml>(result);
+	std::optional<ParserTypes::Yaml> GetIfOk() const {
+		if (std::holds_alternative<ParserTypes::Yaml>(result)) return std::get<ParserTypes::Yaml>(result);
 		return std::nullopt;
 	}
 
@@ -56,15 +56,15 @@ private:
 	void Expect(char c);
 	void ExpectEither(std::initializer_list<char> list);
 
-	String ParseString();
-	Number ParseNumber();
-	Boolean ParseBoolean();
-	Null ParseNull();
+	ParserTypes::String ParseString();
+	ParserTypes::Number ParseNumber();
+	ParserTypes::Boolean ParseBoolean();
+	ParserTypes::Null ParseNull();
 
-	Object ParseYamlObject();
-	Object ParseJsonObject();
-	Array ParseYamlArray();
-	Array ParseJsonArray();
+	ParserTypes::Object ParseYamlObject();
+	ParserTypes::Object ParseJsonObject();
+	ParserTypes::Array ParseYamlArray();
+	ParserTypes::Array ParseJsonArray();
 	
 public:
 	YamlParser(std::ifstream& stream) : stream(stream) {

--- a/YamlValidator/YamlParser.h
+++ b/YamlValidator/YamlParser.h
@@ -7,6 +7,8 @@
 
 #include "Types.h"
 
+using namespace ParserTypes;
+
 enum ParserError {
 	InvalidIndentation,
 	ItemWithoutData,
@@ -15,22 +17,22 @@ enum ParserError {
 
 class ParserResult {
 private:
-	std::variant<ParserTypes::Yaml, ParserError> result;
+	std::variant<Yaml, ParserError> result;
 
 public:
-	ParserResult(ParserTypes::Yaml ok) : result(ok) {}
+	ParserResult(Yaml ok) : result(ok) {}
 	ParserResult(ParserError error) : result(error) {}
 
-	bool IsOk() const { return std::holds_alternative<ParserTypes::Yaml>(result); }
+	bool IsOk() const { return std::holds_alternative<Yaml>(result); }
 
 	bool IsError() const { return std::holds_alternative<ParserError>(result); }
 
-	ParserTypes::Yaml GetResult() const { return std::get<ParserTypes::Yaml>(result); }
+	Yaml GetResult() const { return std::get<::Yaml>(result); }
 
 	ParserError GetError() const { return std::get<ParserError>(result); }
 
-	std::optional<ParserTypes::Yaml> GetIfOk() const {
-		if (std::holds_alternative<ParserTypes::Yaml>(result)) return std::get<ParserTypes::Yaml>(result);
+	std::optional<Yaml> GetIfOk() const {
+		if (std::holds_alternative<Yaml>(result)) return std::get<Yaml>(result);
 		return std::nullopt;
 	}
 
@@ -56,15 +58,15 @@ private:
 	void Expect(char c);
 	void ExpectEither(std::initializer_list<char> list);
 
-	ParserTypes::String ParseString();
-	ParserTypes::Number ParseNumber();
-	ParserTypes::Boolean ParseBoolean();
-	ParserTypes::Null ParseNull();
+	String ParseString();
+	Number ParseNumber();
+	Boolean ParseBoolean();
+	Null ParseNull();
 
-	ParserTypes::Object ParseYamlObject();
-	ParserTypes::Object ParseJsonObject();
-	ParserTypes::Array ParseYamlArray();
-	ParserTypes::Array ParseJsonArray();
+	Object ParseYamlObject();
+	Object ParseJsonObject();
+	Array ParseYamlArray();
+	Array ParseJsonArray();
 	
 public:
 	YamlParser(std::ifstream& stream) : stream(stream) {


### PR DESCRIPTION
nödvändigt för att kunna explicit referera till Types.h definierade typer och undvika namn konflikter. 

skillnaden är att man behöver referera till typerna som:
```c++
ParserTypes::String
```

istället för bara
```c++
String
``` 